### PR TITLE
Output warning if input_data series name is not in data_column_names

### DIFF
--- a/templatefitter/binned_distributions/binned_distribution.py
+++ b/templatefitter/binned_distributions/binned_distribution.py
@@ -330,6 +330,11 @@ class BinnedDistributionFromData(BinnedDistribution):
             data_column_names: DataColumnNamesInput = None
     ) -> np.ndarray:
         if isinstance(in_data, pd.Series):
+            if data_column_names is not None and in_data.name not in data_column_names:
+                logging.warn(
+                    f"The data series name \"{in_data.name}\" is not in the data_column_names "
+                    f"{data_column_names}.\nMake sure you provided the data for the correct variable."
+                )
             data = in_data.values
         elif isinstance(in_data, pd.DataFrame):
             if data_column_names is None:

--- a/templatefitter/binned_distributions/binned_distribution.py
+++ b/templatefitter/binned_distributions/binned_distribution.py
@@ -331,10 +331,8 @@ class BinnedDistributionFromData(BinnedDistribution):
     ) -> np.ndarray:
         if isinstance(in_data, pd.Series):
             if data_column_names is not None and in_data.name not in data_column_names:
-                logging.warn(
-                    f"The data series name \"{in_data.name}\" is not in the data_column_names "
-                    f"{data_column_names}.\nMake sure you provided the data for the correct variable."
-                )
+                logging.warn(f"The data series name '{in_data.name}' is not in the data_column_names "
+                             f"{data_column_names}.\nMake sure you provided the data for the correct variable.")
             data = in_data.values
         elif isinstance(in_data, pd.DataFrame):
             if data_column_names is None:


### PR DESCRIPTION
I just had a bug in my code, which looked something like this:

```python
Mbc = HistVariable(df_label="Mbc", ...)
hist_plot = SimpleHistogramPlot(Mbc)
hist_plot.add_component("label", df.M, ...)
```
In this case `df` is a pandas dataframe, and I accidentally inserted `df.M` instead of `df.Mbc`. I wouldn't have had that problem if I had just given whole dataframes to `add_component`, but decided to be explicit and made and error.

In this PR I added a check, which in the case of a pandas series checks if the series name (if it exists) is in the list of `data_columnn_names`. If not, it issues a warning. I first thought about raising a `ValueError`,  but then thought there might be cases where you want to make a histogram for multiple series with different names, e.g. `isSignal` and `isSignalAcceptMissing...`. Series which are not from a dataframe are usually without a name and there the check is not done.

Warning in action:
![Bildschirmfoto vom 2020-02-12 23-56-18](https://user-images.githubusercontent.com/5121824/74385211-519f2f80-4df3-11ea-8da9-7c9466cb9334.png)
