### PR TITLE
Parantheses missing in get_bin_counts

### DIFF
--- a/templatefitter/plotter/histogram_plots.py
+++ b/templatefitter/plotter/histogram_plots.py
@@ -133,9 +133,9 @@ class StackedHistogramPlot(HistogramPlot):
         histogram = list(self._histograms.histograms)[0]
 
         ax.hist(
-            x=[histogram.binning.bin_mids[0] for _ in histogram.get_bin_counts],
+            x=[histogram.binning.bin_mids[0] for _ in histogram.get_bin_counts()],
             bins=self.bin_edges,
-            weights=histogram.get_bin_counts,
+            weights=histogram.get_bin_counts(),
             stacked=True,
             edgecolor="black",
             lw=0.3,


### PR DESCRIPTION
With the latest PR I thought my stacked histogram would be working, but I still got erros, but now with this fix it works.