### PR TITLE
Import submodules

### DIFF
--- a/templatefitter/__init__.py
+++ b/templatefitter/__init__.py
@@ -1,0 +1,8 @@
+import templatefitter.fitter
+import templatefitter.minimizer
+import templatefitter.stats
+import templatefitter.toy_study
+import templatefitter.utility
+import templatefitter.fit_model
+import templatefitter.binned_distributions
+import templatefitter.plotter


### PR DESCRIPTION
I have been doing something like

```python
import templatefitter as tf
```

and then have accessed submodules like ``tf.fitter.<...>``.

Is there any reason this should not happen by default?

I understand that you removed the ``from X import *`` statements, but is there a reason, why I should have to import all submodules manually?