### PR TITLE
Performance improvements

### DIFF
--- a/templatefitter/fit_model/model_builder.py
+++ b/templatefitter/fit_model/model_builder.py
@@ -16,7 +16,7 @@ from typing import Optional, Union, List, Tuple, Dict, Sequence
 from templatefitter.utility import xlogyx, cov2corr
 
 from templatefitter.binned_distributions.weights import WeightsInputType
-from templatefitter.binned_distributions.binned_distribution import DataInputType
+from templatefitter.binned_distributions.binned_distribution import DataInputType, Binning
 
 from templatefitter.fit_model.template import Template
 from templatefitter.fit_model.component import Component
@@ -129,57 +129,58 @@ class FitModel:
 
     # region Basic Properties
     # Attributes forwarded to self._channels
+
     @immutable_cached_property
-    def binning(self):
+    def binning(self) -> Tuple[Binning, ...]:
         return self._channels.binning
 
     @immutable_cached_property
-    def max_number_of_bins_flattened(self):
-        return self._channels.max_number_of_bins_flattened
-
-    @immutable_cached_property
-    def min_number_of_independent_yields(self):
-        return self._channels.min_number_of_independent_yields
-
-    @immutable_cached_property
-    def number_of_bins_flattened_per_channel(self):
-        return self._channels.number_of_bins_flattened_per_channel
-
-    @immutable_cached_property
-    def number_of_components(self):
-        return self._channels.number_of_components
-
-    @immutable_cached_property
-    def number_of_dependent_templates(self):
-        return self._channels.number_of_dependent_templates
-
-    @immutable_cached_property
-    def number_of_expected_independent_yields(self):
-        return self._channels.number_of_expected_independent_yields
-
-    @immutable_cached_property
-    def number_of_fraction_parameters(self):
-        return self._channels.number_of_fraction_parameters
-
-    @immutable_cached_property
-    def number_of_independent_templates(self):
-        return self._channels.number_of_independent_templates
-
-    @immutable_cached_property
-    def number_of_templates(self):
-        return self._channels.number_of_templates
-
-    @immutable_cached_property
-    def template_bin_counts(self):
+    def template_bin_counts(self) -> np.ndarray:
         return self._channels.template_bin_counts
 
     @immutable_cached_property
-    def total_number_of_templates(self):
-        return self._channels.total_number_of_templates
+    def max_number_of_bins_flattened(self) -> int:
+        return self._channels.max_number_of_bins_flattened
+
+    @immutable_cached_property
+    def number_of_bins_flattened_per_channel(self) -> List[int]:
+        return self._channels.number_of_bins_flattened_per_channel
 
     @property
     def number_of_channels(self) -> int:
         return len(self._channels)
+
+    @immutable_cached_property
+    def number_of_components(self) -> Tuple[int, ...]:
+        return self._channels.number_of_components
+
+    @immutable_cached_property
+    def min_number_of_independent_yields(self) -> int:
+        return self._channels.min_number_of_independent_yields
+
+    @immutable_cached_property
+    def number_of_expected_independent_yields(self) -> int:
+        return self._channels.number_of_expected_independent_yields
+
+    @immutable_cached_property
+    def total_number_of_templates(self) -> int:
+        return self._channels.total_number_of_templates
+
+    @immutable_cached_property
+    def number_of_templates(self) -> Tuple[int, ...]:
+        return self._channels.number_of_templates
+
+    @immutable_cached_property
+    def number_of_dependent_templates(self) -> Tuple[int, ...]:
+        return self._channels.number_of_dependent_templates
+
+    @immutable_cached_property
+    def number_of_independent_templates(self) -> Tuple[int, ...]:
+        return self._channels.number_of_independent_templates
+
+    @immutable_cached_property
+    def number_of_fraction_parameters(self) -> Tuple[int, ...]:
+        return self._channels.number_of_fraction_parameters
 
     @property
     def fraction_conversion(self) -> FractionConversionInfo:

--- a/templatefitter/fit_model/model_builder.py
+++ b/templatefitter/fit_model/model_builder.py
@@ -15,8 +15,9 @@ from typing import Optional, Union, List, Tuple, Dict, Sequence
 
 from templatefitter.utility import xlogyx, cov2corr
 
+from templatefitter.binned_distributions import Binning
 from templatefitter.binned_distributions.weights import WeightsInputType
-from templatefitter.binned_distributions.binned_distribution import DataInputType, Binning
+from templatefitter.binned_distributions.binned_distribution import DataInputType
 
 from templatefitter.fit_model.template import Template
 from templatefitter.fit_model.component import Component

--- a/templatefitter/fit_model/model_builder.py
+++ b/templatefitter/fit_model/model_builder.py
@@ -780,11 +780,10 @@ class FitModel:
         bin_nuisance_param_indices = self._params.get_parameter_indices_for_type(
             parameter_type=ParameterHandler.bin_nuisance_parameter_type,
         )
+        self.bin_nuisance_parameter_slice = create_slice_if_contiguous(bin_nuisance_param_indices)
 
         if not self._bin_nuisance_params_checked:
             self._check_bin_nuisance_parameters()
-
-        self.bin_nuisance_parameter_slice = create_slice_if_contiguous(bin_nuisance_param_indices)
 
         return np.array(bin_nuisance_param_indices)
 
@@ -1149,6 +1148,18 @@ class FitModel:
 
         constraint_indices = [c.constraint_index for c in self._constraint_container]
         self.constraint_slice = create_slice_if_contiguous(constraint_indices)
+        if self.constraint_slice is not None:
+
+            constr_param_values = self._params.get_parameters_by_index(constraint_indices)
+            if isinstance(constr_param_values, float):
+                assert len(self._params.get_parameters_by_slice(self.constraint_slice)) == 1
+                assert all([constr_param_values] == self._params.get_parameters_by_slice(self.constraint_slice))
+            else:
+                assert len(self._params.get_parameters_by_slice(self.constraint_slice)) == len(constr_param_values)
+                assert all(
+                    self._params.get_parameters_by_index(constraint_indices)
+                    == self._params.get_parameters_by_slice(self.constraint_slice)
+                )
 
         return np.array(constraint_indices)
 
@@ -1567,6 +1578,19 @@ class FitModel:
                             ],
                         )
                         index_counter += n_bins
+
+        if self.bin_nuisance_parameter_slice is not None:
+
+            nui_param_values = self._params.get_parameters_by_index(nu_is)
+            if isinstance(nui_param_values, float):
+                assert len(self._params.get_parameters_by_slice(self.bin_nuisance_parameter_slice)) == 1
+                assert all([nui_param_values] == self._params.get_parameters_by_slice(self.bin_nuisance_parameter_slice))
+
+            else:
+                assert len(self._params.get_parameters_by_slice(self.bin_nuisance_parameter_slice)) == len(
+                    nui_param_values
+                )
+                assert all(nui_param_values == self._params.get_parameters_by_slice(self.bin_nuisance_parameter_slice))
 
         self._bin_nuisance_params_checked = True
 

--- a/templatefitter/fit_model/model_builder.py
+++ b/templatefitter/fit_model/model_builder.py
@@ -8,7 +8,6 @@ import operator
 import numpy as np
 import scipy.stats as scipy_stats
 
-from numba import jit
 from scipy.linalg import block_diag
 from abc import ABC, abstractmethod
 from typing import Optional, Union, List, Tuple, Dict, Sequence
@@ -127,47 +126,54 @@ class FitModel:
         self._random_state = np.random.RandomState(seed=7694747)  # type: np.random.RandomState
 
     # region Basic Properties
-    # Attributes forwarded to self._channels via __getattr__()
-    _channel_attrs = [
-        "binning",
-        "max_number_of_bins_flattened",
-        "min_number_of_independent_yields",
-        "number_of_bins_flattened_per_channel",
-        "number_of_components",
-        "number_of_dependent_templates",
-        "number_of_expected_independent_yields",
-        "number_of_fraction_parameters",
-        "number_of_independent_templates",
-        "number_of_templates",
-        "template_bin_counts",
-        "total_number_of_templates",
-    ]
+    # Attributes forwarded to self._channels
+    @immutable_cached_property
+    def binning(self):
+        return self._channels.binning
 
-    def __getattribute__(self, attr):
-        """
-        Forwarding some attributes to self._channels for backwards compatibility.
-        :param attr: The attribute name
-        :return: A forwarded attribute of ModelChannels
-        """
+    @immutable_cached_property
+    def max_number_of_bins_flattened(self):
+        return self._channels.max_number_of_bins_flattened
 
-        try:
-            return super().__getattribute__(attr)
-        except AttributeError:
-            if attr in self._channel_attrs:
-                try:
-                    return getattr(self._channels, attr)
-                except AttributeError:
-                    raise AttributeError(
-                        f"Forwarded attribute access from {self.__class__.__name__} to"
-                        f" {self._channels.__class__.__name__} which also has no attribute {attr}."
-                    )
-            elif attr in dir(self._channels):
-                raise AttributeError(
-                    f"Attribute {attr} exists for {self._channels.__class__.__name__} but is not forwarded "
-                    f"to {self.__class__.__name__}."
-                )
-            else:
-                raise
+    @immutable_cached_property
+    def min_number_of_independent_yields(self):
+        return self._channels.min_number_of_independent_yields
+
+    @immutable_cached_property
+    def number_of_bins_flattened_per_channel(self):
+        return self._channels.number_of_bins_flattened_per_channel
+
+    @immutable_cached_property
+    def number_of_components(self):
+        return self._channels.number_of_components
+
+    @immutable_cached_property
+    def number_of_dependent_templates(self):
+        return self._channels.number_of_dependent_templates
+
+    @immutable_cached_property
+    def number_of_expected_independent_yields(self):
+        return self._channels.number_of_expected_independent_yields
+
+    @immutable_cached_property
+    def number_of_fraction_parameters(self):
+        return self._channels.number_of_fraction_parameters
+
+    @immutable_cached_property
+    def number_of_independent_templates(self):
+        return self._channels.number_of_independent_templates
+
+    @immutable_cached_property
+    def number_of_templates(self):
+        return self._channels.number_of_templates
+
+    @immutable_cached_property
+    def template_bin_counts(self):
+        return self._channels.template_bin_counts
+
+    @immutable_cached_property
+    def total_number_of_templates(self):
+        return self._channels.total_number_of_templates
 
     @property
     def number_of_channels(self) -> int:
@@ -1822,7 +1828,6 @@ class FitModel:
 
         return bin_count
 
-    @jit(forceobj=True)
     def _gauss_term(
         self,
         bin_nuisance_parameter_vector: np.ndarray,
@@ -1890,7 +1895,6 @@ class FitModel:
 
         return self._masked_data_bin_counts
 
-    @jit(forceobj=True)
     def chi2(
         self,
         parameter_vector: np.ndarray,

--- a/templatefitter/fit_model/model_builder.py
+++ b/templatefitter/fit_model/model_builder.py
@@ -1107,7 +1107,6 @@ class FitModel:
         #           -> Think about how nuisance parameter must be handled in general to make all options possible!!!
         # TODO: General implementation of creation of nuisance parameters for different options of uncertainty handling!
 
-        nuisance_sigma = 1.0  # type: float
         initial_nuisance_value = 0.0  # type: float
 
         for counter in range(template.num_bins_total):
@@ -1116,8 +1115,6 @@ class FitModel:
                 parameter_type=ParameterHandler.bin_nuisance_parameter_type,
                 floating=True,
                 initial_value=initial_nuisance_value,
-                constrain_to_value=initial_nuisance_value,
-                constraint_sigma=nuisance_sigma,
             )
             bin_nuisance_model_params.append(model_parameter)
             bin_nuisance_model_param_indices.append(model_param_index)

--- a/templatefitter/fit_model/model_builder.py
+++ b/templatefitter/fit_model/model_builder.py
@@ -115,6 +115,9 @@ class FitModel:
 
         self._bin_nuisance_params_checked = False  # type: bool
 
+        self.bin_nuisance_parameter_slice = None  # type: Optional[Tuple[int, int]]
+        self.constraint_slice = None  # type: Optional[Tuple[int, int]]
+
         self._constraint_container = ConstraintContainer()  # type: ConstraintContainer
 
         self._template_shapes_checked = False  # type: bool
@@ -762,7 +765,7 @@ class FitModel:
         return self._inverse_template_bin_correlation_matrix
 
     @immutable_cached_property
-    def floating_nuisance_parameter_indices(self) -> Union[np.ndarray, slice, List[int]]:
+    def floating_nuisance_parameter_indices(self) -> Union[np.ndarray, List[int]]:
         all_bin_nuisance_parameter_indices = self.bin_nuisance_parameter_indices
         floating_nuisance_parameter_indices = []
         for all_index in all_bin_nuisance_parameter_indices:
@@ -770,10 +773,10 @@ class FitModel:
                 param_id = sum(self._params.floating_parameter_mask[: all_index + 1]) - 1  # type: int
                 floating_nuisance_parameter_indices.append(param_id)
 
-        return create_slice_if_contiguous(floating_nuisance_parameter_indices)
+        return np.array(floating_nuisance_parameter_indices)
 
     @immutable_cached_property
-    def bin_nuisance_parameter_indices(self) -> Union[np.ndarray, slice, List[int]]:
+    def bin_nuisance_parameter_indices(self) -> Union[np.ndarray, List[int]]:
         bin_nuisance_param_indices = self._params.get_parameter_indices_for_type(
             parameter_type=ParameterHandler.bin_nuisance_parameter_type,
         )
@@ -781,7 +784,9 @@ class FitModel:
         if not self._bin_nuisance_params_checked:
             self._check_bin_nuisance_parameters()
 
-        return create_slice_if_contiguous(bin_nuisance_param_indices)
+        self.bin_nuisance_parameter_slice = create_slice_if_contiguous(bin_nuisance_param_indices)
+
+        return np.array(bin_nuisance_param_indices)
 
     @immutable_cached_property
     def relative_shape_uncertainties(self) -> np.ndarray:
@@ -1140,8 +1145,12 @@ class FitModel:
     # region Constraint-related methods and properties
 
     @immutable_cached_property
-    def constraint_indices(self) -> Union[np.ndarray, slice, List[int]]:
-        return create_slice_if_contiguous([c.constraint_index for c in self._constraint_container])
+    def constraint_indices(self) -> Union[np.ndarray, List[int]]:
+
+        constraint_indices = [c.constraint_index for c in self._constraint_container]
+        self.constraint_slice = create_slice_if_contiguous(constraint_indices)
+
+        return np.array(constraint_indices)
 
     @immutable_cached_property
     def constraint_values(self) -> List[float]:
@@ -1639,9 +1648,15 @@ class FitModel:
         self,
         parameter_vector: np.ndarray,
     ) -> Tuple[np.ndarray, np.ndarray]:
-        nuisance_parameter_vector = self._params.get_combined_parameters_by_index(
-            parameter_vector=parameter_vector, indices=self.bin_nuisance_parameter_indices, ncall=self.ncall
-        )
+
+        if self.bin_nuisance_parameter_slice is not None:
+            nuisance_parameter_vector = self._params.get_combined_parameters_by_slice(
+                parameter_vector=parameter_vector, slicing=self.bin_nuisance_parameter_slice, ncall=self.ncall
+            )
+        else:
+            nuisance_parameter_vector = self._params.get_combined_parameters_by_index(
+                parameter_vector=parameter_vector, indices=self.bin_nuisance_parameter_indices, ncall=self.ncall
+            )
 
         new_nuisance_matrix_shape = self._nuisance_matrix_shape
         complex_reshaping_required = not all(
@@ -1877,11 +1892,18 @@ class FitModel:
         if not self._constraint_container:
             return 0.0
 
-        constraint_pars = self._params.get_combined_parameters_by_index(
-            parameter_vector=parameter_vector,
-            indices=self.constraint_indices,
-            ncall=self.ncall,
-        )
+        if self.constraint_slice is not None:
+            constraint_pars = self._params.get_combined_parameters_by_slice(
+                parameter_vector=parameter_vector,
+                slicing=self.constraint_slice,
+                ncall=self.ncall,
+            )
+        else:
+            constraint_pars = self._params.get_combined_parameters_by_index(
+                parameter_vector=parameter_vector,
+                indices=self.constraint_indices,
+                ncall=self.ncall,
+            )
 
         constraint_term = np.sum(((self.constraint_values - constraint_pars) / self.constraint_sigmas) ** 2)
 

--- a/templatefitter/fit_model/parameter_handler.py
+++ b/templatefitter/fit_model/parameter_handler.py
@@ -82,9 +82,8 @@ class ParameterHandler:
         self._parameters_by_type = {k: [] for k in ParameterHandler.parameter_types}  # type: Dict[str, List[int]]
         self._redefined_params_dict = {}  # type: Dict[str, ParameterResetInfo]
 
-        self._floating_mask = None  # type: Optional[Tuple[bool, ...]]
+        self._floating_mask = None  # type: Optional[np.ndarray[bool, ...]]
         self._floating_conversion_vector = None  # type: Optional[np.ndarray]
-        self._floating_conversion_matrix = None  # type: Optional[np.ndarray]
         self._floating_parameter_indices = None  # type: Optional[np.ndarray]
         self._initial_values_of_floating_parameters = None  # type: Optional[np.ndarray]
 
@@ -223,11 +222,9 @@ class ParameterHandler:
         assert not self._is_finalized
         assert self._floating_mask is None
         assert self._floating_conversion_vector is None
-        assert self._floating_conversion_matrix is None
 
         self._floating_mask = self._create_floating_parameter_mask()
         self._floating_conversion_vector = self._create_conversion_vector()
-        self._floating_conversion_matrix = self._create_conversion_matrix()
 
         self._check_parameter_conversion()
 
@@ -236,27 +233,14 @@ class ParameterHandler:
 
         self._is_finalized = True
 
-    def _create_floating_parameter_mask(self) -> Tuple[bool, ...]:
-        return tuple([p_info.floating for p_info in self._parameter_infos])
+    def _create_floating_parameter_mask(self) -> np.ndarray[bool, ...]:
+        return np.array([p_info.floating for p_info in self._parameter_infos])
 
     def _create_conversion_vector(self) -> np.ndarray:
         # Is the inverse of the floating_parameter_mask converted to integers times the parameters
         # and thus yields the fixed parameters.
         conversion_vector = np.array([0 if m else 1 for m in self.floating_parameter_mask])
         return conversion_vector * self._np_pars
-
-    def _create_conversion_matrix(self) -> np.ndarray:
-        n_floating = sum(self.floating_parameter_mask)
-        assert isinstance(n_floating, int), n_floating
-        conversion_matrix = np.zeros((n_floating, len(self.floating_parameter_mask)))
-
-        i_index = 0
-        for j_index, mask_bool in enumerate(self.floating_parameter_mask):
-            if mask_bool:
-                conversion_matrix[i_index, j_index] = 1
-                i_index += 1
-
-        return conversion_matrix
 
     def _create_floating_parameter_indices_info(self) -> None:
         self._floating_parameter_indices = np.array(
@@ -299,7 +283,7 @@ class ParameterHandler:
         )
 
     @property
-    def floating_parameter_mask(self) -> Tuple[bool, ...]:
+    def floating_parameter_mask(self) -> np.ndarray[bool, ...]:
         assert self._floating_mask is not None
         return self._floating_mask
 
@@ -308,16 +292,13 @@ class ParameterHandler:
         assert self._floating_conversion_vector is not None
         return self._floating_conversion_vector
 
-    @property
-    def conversion_matrix(self) -> np.ndarray:
-        assert self._floating_conversion_matrix is not None
-        return self._floating_conversion_matrix
-
     def get_combined_parameters(
         self,
         parameter_vector: np.ndarray,
     ) -> np.ndarray:
-        return parameter_vector @ self.conversion_matrix + self.conversion_vector
+        zero_array = np.zeros(len(self.floating_parameter_mask))
+        zero_array[self.floating_parameter_mask] = parameter_vector
+        return zero_array + self.conversion_vector
 
     def get_combined_parameters_by_index(
         self,
@@ -340,25 +321,11 @@ class ParameterHandler:
     def _check_parameter_conversion(self) -> None:
         assert self._floating_mask is not None
         assert self._floating_conversion_vector is not None
-        assert self._floating_conversion_matrix is not None
 
         assert len(self._floating_conversion_vector.shape) == 1, self._floating_conversion_vector.shape
-        assert len(self._floating_conversion_matrix.shape) == 2, self._floating_conversion_matrix.shape
         assert len(self._floating_mask) == len(self._floating_conversion_vector), (
             len(self._floating_mask),
             len(self._floating_conversion_vector),
-        )
-
-        assert len(self._floating_conversion_vector) == self._floating_conversion_matrix.shape[1], (
-            len(self._floating_conversion_vector),
-            self._floating_conversion_matrix.shape[1],
-            self._floating_conversion_matrix.shape,
-        )
-
-        n_floating = sum(self.floating_parameter_mask)
-        assert n_floating == self._floating_conversion_matrix.shape[0], (
-            n_floating,
-            self._floating_conversion_matrix.shape[0],
         )
 
         assert all(
@@ -370,7 +337,7 @@ class ParameterHandler:
         self,
         parameter_vector: np.ndarray,
     ) -> None:
-        self._np_pars = parameter_vector @ self.conversion_matrix + self.conversion_vector
+        self._np_pars = self.get_combined_parameters(parameter_vector)
 
     def get_index(
         self,

--- a/templatefitter/fit_model/parameter_handler.py
+++ b/templatefitter/fit_model/parameter_handler.py
@@ -82,12 +82,14 @@ class ParameterHandler:
         self._parameters_by_type = {k: [] for k in ParameterHandler.parameter_types}  # type: Dict[str, List[int]]
         self._redefined_params_dict = {}  # type: Dict[str, ParameterResetInfo]
 
-        self._floating_mask = None  # type: Optional[np.ndarray[bool, ...]]
+        self._floating_mask = None  # type: Optional[np.ndarray]
         self._floating_conversion_vector = None  # type: Optional[np.ndarray]
         self._floating_parameter_indices = None  # type: Optional[np.ndarray]
         self._initial_values_of_floating_parameters = None  # type: Optional[np.ndarray]
 
         self._is_finalized = False  # type: bool
+
+        self.combined_parameters_cache = (0, None)
 
     def add_parameter(
         self,
@@ -233,7 +235,7 @@ class ParameterHandler:
 
         self._is_finalized = True
 
-    def _create_floating_parameter_mask(self) -> np.ndarray[bool, ...]:
+    def _create_floating_parameter_mask(self) -> np.ndarray:
         return np.array([p_info.floating for p_info in self._parameter_infos])
 
     def _create_conversion_vector(self) -> np.ndarray:
@@ -283,7 +285,7 @@ class ParameterHandler:
         )
 
     @property
-    def floating_parameter_mask(self) -> np.ndarray[bool, ...]:
+    def floating_parameter_mask(self) -> np.ndarray:
         assert self._floating_mask is not None
         return self._floating_mask
 
@@ -295,19 +297,28 @@ class ParameterHandler:
     def get_combined_parameters(
         self,
         parameter_vector: np.ndarray,
+        ncall=None,
     ) -> np.ndarray:
-        zero_array = np.zeros(len(self.floating_parameter_mask))
-        zero_array[self.floating_parameter_mask] = parameter_vector
-        return zero_array + self.conversion_vector
+
+        if ncall == self.combined_parameters_cache[0]:
+            return self.combined_parameters_cache[1]
+        else:
+            zero_array = np.zeros(len(self.floating_parameter_mask))
+            zero_array[self.floating_parameter_mask] = parameter_vector
+            result = zero_array + self.conversion_vector
+            if ncall is not None:
+                self.combined_parameters_cache = (ncall, result)
+            return result
 
     def get_combined_parameters_by_index(
         self,
         parameter_vector: np.ndarray,
         indices: Union[int, List[int]],
+        ncall=None,
     ) -> np.ndarray:
         # This getter combines floating parameters provided via the argument 'parameter_vector' and fixed parameters
         # and then yields the parameters with the indices provided via the 'indices' argument.
-        return self.get_combined_parameters(parameter_vector=parameter_vector)[indices]
+        return self.get_combined_parameters(parameter_vector=parameter_vector, ncall=ncall)[indices]
 
     def get_combined_parameters_by_slice(
         self,

--- a/templatefitter/fit_model/parameter_handler.py
+++ b/templatefitter/fit_model/parameter_handler.py
@@ -313,7 +313,7 @@ class ParameterHandler:
     def get_combined_parameters_by_index(
         self,
         parameter_vector: np.ndarray,
-        indices: Union[int, List[int], slice],
+        indices: Union[int, List[int]],
         ncall: Optional[int] = None,
     ) -> np.ndarray:
         # This getter combines floating parameters provided via the argument 'parameter_vector' and fixed parameters
@@ -324,10 +324,11 @@ class ParameterHandler:
         self,
         parameter_vector: np.ndarray,
         slicing: Tuple[Optional[int], Optional[int]],
+        ncall: Optional[int] = None,
     ) -> np.ndarray:
         # This getter combines floating parameters provided via the argument 'parameter_vector' and fixed parameters
         # and then yields the parameters for the slicing provided via the 'slicing' argument.
-        return self.get_combined_parameters(parameter_vector=parameter_vector)[slicing[0] : slicing[1]]
+        return self.get_combined_parameters(parameter_vector=parameter_vector, ncall=ncall)[slicing[0] : slicing[1]]
 
     def _check_parameter_conversion(self) -> None:
         assert self._floating_mask is not None

--- a/templatefitter/fit_model/parameter_handler.py
+++ b/templatefitter/fit_model/parameter_handler.py
@@ -89,7 +89,7 @@ class ParameterHandler:
 
         self._is_finalized = False  # type: bool
 
-        self.combined_parameters_cache = (0, None)
+        self.combined_parameters_cache = (0, None)  # type: Tuple[float, Optional[np.ndarray]]
 
     def add_parameter(
         self,
@@ -297,7 +297,7 @@ class ParameterHandler:
     def get_combined_parameters(
         self,
         parameter_vector: np.ndarray,
-        ncall=None,
+        ncall: Optional[int] = None,
     ) -> np.ndarray:
 
         if ncall == self.combined_parameters_cache[0]:
@@ -313,8 +313,8 @@ class ParameterHandler:
     def get_combined_parameters_by_index(
         self,
         parameter_vector: np.ndarray,
-        indices: Union[int, List[int]],
-        ncall=None,
+        indices: Union[int, List[int], slice],
+        ncall: Optional[int] = None,
     ) -> np.ndarray:
         # This getter combines floating parameters provided via the argument 'parameter_vector' and fixed parameters
         # and then yields the parameters with the indices provided via the 'indices' argument.

--- a/templatefitter/fit_model/utility.py
+++ b/templatefitter/fit_model/utility.py
@@ -4,8 +4,7 @@ Utility functions
 
 import numpy as np
 
-from typing import Tuple, Callable, Sequence, Union
-
+from typing import Tuple, Callable, Sequence, Optional
 
 __all__ = [
     "pad_sequences",
@@ -131,12 +130,10 @@ class immutable_cached_property:
         return value
 
 
-def create_slice_if_contiguous(indices: Sequence[int]) -> Union[slice, np.ndarray]:
-
+def create_slice_if_contiguous(indices: Sequence[int]) -> Optional[Tuple[int, int]]:
     contiguous_equivalent = list(range(min(indices), max(indices) + 1))
 
     if (len(indices) == len(contiguous_equivalent)) and all((a == b for a, b in zip(indices, contiguous_equivalent))):
-        return slice(min(indices), max(indices))
-
+        return min(indices), max(indices)
     else:
-        return np.ndarray(indices)
+        return None

--- a/templatefitter/fit_model/utility.py
+++ b/templatefitter/fit_model/utility.py
@@ -4,7 +4,7 @@ Utility functions
 
 import numpy as np
 
-from typing import Tuple, Callable
+from typing import Tuple, Callable, Sequence, Union
 
 
 __all__ = [
@@ -129,3 +129,14 @@ class immutable_cached_property:
         value = self._function(obj)
         setattr(obj, self._function.__name__, value)
         return value
+
+
+def create_slice_if_contiguous(indices: Sequence[int]) -> Union[slice, np.ndarray]:
+
+    contiguous_equivalent = list(range(min(indices), max(indices) + 1))
+
+    if (len(indices) == len(contiguous_equivalent)) and all((a == b for a, b in zip(indices, contiguous_equivalent))):
+        return slice(min(indices), max(indices))
+
+    else:
+        return np.ndarray(indices)

--- a/templatefitter/fit_model/utility.py
+++ b/templatefitter/fit_model/utility.py
@@ -134,6 +134,7 @@ def create_slice_if_contiguous(indices: Sequence[int]) -> Optional[Tuple[int, in
     contiguous_equivalent = list(range(min(indices), max(indices) + 1))
 
     if (len(indices) == len(contiguous_equivalent)) and all((a == b for a, b in zip(indices, contiguous_equivalent))):
-        return min(indices), max(indices)
+
+        return min(indices), max(indices) + 1
     else:
         return None

--- a/templatefitter/minimizer.py
+++ b/templatefitter/minimizer.py
@@ -75,7 +75,7 @@ class MinimizerParameters:
         }  # type: Dict[str, Any]
         return tabulate.tabulate(data, headers="keys")
 
-    def get_param_value(self, param_id: Union[int, str]) -> float:
+    def get_param_value(self, param_id: Union[int, str, np.integer]) -> float:
         """
         Returns value of parameter specified by `param_id`.
 
@@ -91,7 +91,7 @@ class MinimizerParameters:
         param_index = self.param_id_to_index(param_id=param_id)
         return self.values[param_index]
 
-    def get_param_error(self, param_id: Union[int, str]) -> float:
+    def get_param_error(self, param_id: Union[int, str, np.integer]) -> float:
         """
         Returns error of parameter specified by `param_id`.
 
@@ -109,7 +109,7 @@ class MinimizerParameters:
 
     def __getitem__(
         self,
-        param_id: Union[int, str],
+        param_id: Union[int, str, np.integer],
     ) -> Tuple[float, float]:
         """
         Gets the value and error of the specified parameter.
@@ -129,7 +129,7 @@ class MinimizerParameters:
         param_index = self.param_id_to_index(param_id=param_id)
         return self.values[param_index], self.errors[param_index]
 
-    def param_id_to_index(self, param_id: Union[int, str]) -> int:
+    def param_id_to_index(self, param_id: Union[int, str, np.integer]) -> int:
         """
         Returns the index of the parameter specified by `param_id`.
 
@@ -142,7 +142,7 @@ class MinimizerParameters:
         -------
         int
         """
-        if isinstance(param_id, int) and (param_id in range(len(self.names))):
+        if isinstance(param_id, (int, np.integer)) and (param_id in range(len(self.names))):
             return param_id
         elif isinstance(param_id, str) and (param_id in self.names):
             return self.names.index(param_id)
@@ -154,7 +154,7 @@ class MinimizerParameters:
 
     def set_param_fixed(
         self,
-        param_id: Union[int, str],
+        param_id: Union[int, str, np.integer],
     ) -> None:
         param_index = self.param_id_to_index(param_id=param_id)
         self._fixed_params[param_index] = True


### PR DESCRIPTION
Hi,

this is a followup to #8 and addresses a few performance issues I've noticed by profiling the example fit. I have removed the __getattribute__ forwarding from #8 (as that was very slow) as well as the numba call (which actually added some overhead to each call). 
In addition I've removed the matrix multiplication in the parameter handler and replaced it with numpy indexing (the very sparse n x n matrix where n is the roughly the number of bins can be quite expensive to compute).  As I have noticed that the function originally containing the matrix multiplication is called 5 times during each fit, I have added a cache for this result as the value should be the same within each call. There are certainly nicer solutions for this cache, however I'd argue that the additional abstraction could also introduce slowdowns.

All in all the proposed changes speed up the basic_example.py by a factor of 3. This has been tested with 200 and 400 bins, each with floating nuisance parameters.